### PR TITLE
fixed album image not being set on launch.

### DIFF
--- a/Player/Classes/Controllers/PandoraPlayer.swift
+++ b/Player/Classes/Controllers/PandoraPlayer.swift
@@ -232,6 +232,7 @@ open class PandoraPlayer: UIViewController {
         configureNavigationBar()
 		configurePlayer()
         configurePlayerSongListView()
+        configureBackgroundImage()
     }
 	
     private func configurePlayerSongListView() {


### PR DESCRIPTION
init: public static func configure(withAVItems items: [AVPlayerItem]) -> PandoraPlayer
Issue: image isn't set in initial configuration.
fix: added function call to configure image.

![initial_image_issue](https://user-images.githubusercontent.com/16448244/36614191-dfc055cc-18a9-11e8-9314-25b1071e6c29.gif)
