### PR TITLE
Update Podspec to Use Latest Version of AudioKit

### DIFF
--- a/PandoraPlayer.podspec
+++ b/PandoraPlayer.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
 
   s.resources = "Player/**/*.{storyboard,xib,xcassets}"
 
-  s.dependency "AudioKit", "4.0.3"
+  s.dependency "AudioKit", "~> 4.0"
 
 end


### PR DESCRIPTION
The current version (4.0.3) is not compatible with the Swift 4.2.1 compiler. This gets rid of the error 'Module compiled with Swift 4.0.2 cannot be imported by the Swift 4.2.1 compiler'.